### PR TITLE
Fix new SSO connection regressions

### DIFF
--- a/src/SsoCredentials/__tests__/getSsoConfig.test.ts
+++ b/src/SsoCredentials/__tests__/getSsoConfig.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import getSsoConfig from '../getSsoConfig';
+import getSsoConfig, { isSsoProfileConfig } from '../getSsoConfig';
 
 // force AWS to run the node_loader so that utils are configured with fs and ini loaders
 // eslint-disable-next-line import/order, import/newline-after-import
@@ -31,6 +31,7 @@ sso_role_name = MyRole
     sso_role_name: 'MyRole',
     sso_start_url: 'https://testing.awsapps.com/start',
   });
+  expect(isSsoProfileConfig(config)).toBe(true);
 
   fs.rmSync(dir, { recursive: true });
 });
@@ -45,8 +46,6 @@ test('it loads the sso config from a file with the new SSO login', () => {
     configPath,
     `
       [testing]
-      sso_start_url = https://testing.awsapps.com/start
-      sso_region = eu-west-1
       sso_account_id = 1234
       sso_role_name = MyRole
       sso_session = test-session
@@ -69,6 +68,7 @@ test('it loads the sso config from a file with the new SSO login', () => {
     sso_session: 'test-session',
     sso_start_url: 'https://testing.awsapps.com/start',
   });
+  expect(isSsoProfileConfig(config)).toBe(true);
 
   fs.rmSync(dir, { recursive: true });
 });

--- a/src/SsoCredentials/__tests__/getSsoConfig.test.ts
+++ b/src/SsoCredentials/__tests__/getSsoConfig.test.ts
@@ -21,6 +21,8 @@ sso_account_id = 1234
 sso_role_name = MyRole
   `);
 
+  process.env.AWS_CONFIG_FILE = configPath;
+
   const config = getSsoConfig({ filename: configPath, profile: 'testing' });
 
   expect(config).toEqual({
@@ -55,6 +57,8 @@ test('it loads the sso config from a file with the new SSO login', () => {
       sso_registration_scopes = sso:account:access
   `,
   );
+
+  process.env.AWS_CONFIG_FILE = configPath;
 
   const config = getSsoConfig({ filename: configPath, profile: 'testing' });
 

--- a/src/SsoCredentials/getSsoConfig.ts
+++ b/src/SsoCredentials/getSsoConfig.ts
@@ -81,9 +81,9 @@ const getSsoSessions = (
     || process.env[sharedConfigFileEnv]
     || iniLoader.getDefaultFilePath(true);
 
-  const config = iniLoader.loadSsoSessionsFrom({
+  const config = iniLoader.loadSsoSessionsFrom ? iniLoader.loadSsoSessionsFrom({
     filename: filenameForSessions,
-  });
+  }) : {};
 
   return config;
 };
@@ -149,7 +149,6 @@ export default function getSsoConfig(options: {
     throw new Error('Cannot load SSO credentials without a profile');
   }
   const profiles = getProfilesFromSsoConfig(
-    // https://github.com/aws/aws-sdk-js/pull/4456
     AWSUtil.iniLoader as unknown as SsoIniLoader,
     options.filename,
   );

--- a/src/SsoCredentials/getSsoConfig.ts
+++ b/src/SsoCredentials/getSsoConfig.ts
@@ -5,7 +5,7 @@ const configOptInEnv = 'AWS_SDK_LOAD_CONFIG';
 const sharedConfigFileEnv = 'AWS_CONFIG_FILE';
 const sharedCredentialsFileEnv = 'AWS_SHARED_CREDENTIALS_FILE';
 
-function isSsoProfileConfig(c: unknown): c is SsoProfileConfig {
+export function isSsoProfileConfig(c: unknown): c is SsoProfileConfig {
   if (c === undefined || c === null) return false;
   if (typeof c !== 'object') return false;
   if (
@@ -117,6 +117,7 @@ const addSsoDataToProfiles = (
         profilesWithSessionData[profileName] = {
           ...profile,
           sso_start_url: session.sso_start_url,
+          sso_region: session.sso_region,
         };
       }
     });

--- a/src/SsoCredentials/getSsoConfig.ts
+++ b/src/SsoCredentials/getSsoConfig.ts
@@ -96,15 +96,14 @@ const addSsoDataToProfiles = (
   sessionConfiguration: ConfigData,
   profiles: Record<string, SsoProfileConfig>,
 ) => {
-  const profileNames = Object.keys(profiles);
   const profilesWithSessionData = profiles;
 
-  profileNames.forEach((profileName) => {
+  Object.entries(profiles).forEach(([profileName, profile]) => {
     sessionConfiguration.keys.forEach((ssoSessionName) => {
-      if (ssoSessionName === profiles[profileName].sso_session) {
+      if (ssoSessionName === profile.sso_session) {
         const session = sessionConfiguration.config[ssoSessionName];
         profilesWithSessionData[profileName] = {
-          ...profiles[profileName],
+          ...profile,
           sso_start_url: session.sso_start_url,
         };
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,13 @@ export type SsoProfileConfig = {
 
 export type SsoIniLoader =
    IniLoader & {
-     loadSsoSessionsFrom(options: LoadFileOptions): IniFileContent;
+     /** New method in aws-sdk.
+      *
+      * Considered optional, in case aws-sdk peer-dependency
+      * is not installed at the correct version.
+      *
+      * See https://github.com/aws/aws-sdk-js/pull/4456 to add this method to aws-sdk types.
+      * */
+     loadSsoSessionsFrom?: (options: LoadFileOptions) => IniFileContent;
      getDefaultFilePath(isConfig: boolean): string;
    };

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,4 +61,5 @@ export type ConfigData = {
 export type SsoIniLoader =
    IniLoader & {
      loadSsoSessionsFrom(options: LoadFileOptions): IniFileContent;
+     getDefaultFilePath(isConfig: boolean): string;
    };

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,12 +52,6 @@ export type SsoProfileConfig = {
   sso_session?: string,
 };
 
-export type ConfigData = {
-  config: IniFileContent;
-  keys: string[];
-  values: Record<string, string>[];
-};
-
 export type SsoIniLoader =
    IniLoader & {
      loadSsoSessionsFrom(options: LoadFileOptions): IniFileContent;


### PR DESCRIPTION
Fix new SSO connection regressions introduced in https://github.com/thomasmichaelwallace/serverless-better-credentials/pull/26
- refactor: simplify forEach loop in addSsoDataToProfiles
- fix: handle profiles from credentials file
- fix: add sso region when using new sso method
- refactor: simplify sso login code

Should close https://github.com/thomasmichaelwallace/serverless-better-credentials/issues/18, https://github.com/thomasmichaelwallace/serverless-better-credentials/issues/27 and https://github.com/thomasmichaelwallace/serverless-better-credentials/issues/28
