### PR TITLE
feat: new enabled flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# JetBrains IDEs (IntelliJ, WebStorm, etc)
+.idea/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ plugins:
   # - ... other plugins
 ```
 
+The following options are supported:
+
+```yaml
+custom:
+  betterCredentials:
+    # Use this flag to turn off the plugin entirely, which you may want for certain stages.
+    # Defaults to true.
+    enabled: true
+```
+
 ## AWS Single Sign On (SSO) Support
 
 AWS SSO profiles configured to work with the AWS CLI should "just work" when this plugin is enabled. This includes prompting and attempting to automatically open the SSO authorization page in your default browser when the credentials require refreshing.

--- a/src/ServerlessBetterCredentials.ts
+++ b/src/ServerlessBetterCredentials.ts
@@ -27,7 +27,7 @@ export default class ServerlessBetterCredentials implements Plugin {
   }
 
   async init() {
-    if (!evaluateBoolean(this.serverless.service.custom.betterCredentials?.enabled, true)) {
+    if (!evaluateBoolean(this.serverless.service.custom?.betterCredentials?.enabled, true)) {
       log.debug('serverless-better-credentials: plugin is disabled - skipping');
       return;
     }

--- a/src/__tests__/ServerlessBetterCredentials.test.ts
+++ b/src/__tests__/ServerlessBetterCredentials.test.ts
@@ -1,12 +1,53 @@
 /* eslint-disable */
 import Serverless from 'serverless';
 import type ServerlessBetterCredentialsType from '../ServerlessBetterCredentials';
+import type { BetterCredentialsPluginOptions } from '../types';
 
 // @ts-ignore - emulate serverless plugin require process
 const ServerlessBetterCredentials: typeof ServerlessBetterCredentialsType = require('..');
+
+const credentials = { getPromise: jest.fn(() => Promise.resolve()) };
+jest.mock('../utils/getCredentials', () => jest.fn(() => ({ credentials })));
 
 test('module can be loaded by the serverless framework', () => {
   const sls = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
   const plugin = new ServerlessBetterCredentials(sls);
   expect(plugin).toBeTruthy();
+});
+
+describe('init', () => {
+  // minimum config necessary to initialize serverless the way our plugin requires
+  const initServerless = async (betterCredentials?: BetterCredentialsPluginOptions) => {
+    const sls = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: '.',
+      configurationFilename: 'serverless.yml',
+      configuration: {
+        service: 'test',
+        provider: 'aws',
+        custom: { betterCredentials },
+      },
+    });
+    await sls.init();
+    return sls;
+  }
+
+  test('init no-ops if disabled', async () => {
+    const sls = await initServerless({ enabled: false });
+    await new ServerlessBetterCredentials(sls).init();
+    expect(credentials.getPromise).not.toHaveBeenCalled();
+  });
+
+  test('init fetches credentials if enabled', async () => {
+    const sls = await initServerless({ enabled: true });
+    await new ServerlessBetterCredentials(sls).init();
+    expect(credentials.getPromise).toHaveBeenCalledTimes(1);
+  });
+
+  test('init fetches credentials by default', async () => {
+    const sls = await initServerless();
+    await new ServerlessBetterCredentials(sls).init();
+    expect(credentials.getPromise).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type BetterCredentialsPluginOptions = {
 
 export type ServerlessWithCustom = Serverless & {
   service: {
-    custom: {
+    custom?: {
       betterCredentials?: BetterCredentialsPluginOptions;
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,23 @@ import { IniFileContent, IniLoader, LoadFileOptions } from 'aws-sdk/lib/shared-i
 import Serverless from 'serverless';
 import Aws from 'serverless/plugins/aws/provider/awsProvider';
 
+export type BetterCredentialsPluginOptions = {
+  /**
+   * Use this flag to turn off the plugin entirely, which you may want for certain stages.
+   * Allows strings to make it easier to use environment variables with serverless.
+   * @default true
+   */
+  enabled?: boolean | string;
+};
+
+export type ServerlessWithCustom = Serverless & {
+  service: {
+    custom: {
+      betterCredentials?: BetterCredentialsPluginOptions;
+    }
+  }
+};
+
 // serverless/lib/plugins/aws/provider.js - getCredentials (return type)
 export type ServerlessAwsCredentials = {
   credentials: AWS.Credentials,

--- a/src/utils/__tests__/evaluateBoolean.test.ts
+++ b/src/utils/__tests__/evaluateBoolean.test.ts
@@ -1,0 +1,23 @@
+import evaluateBoolean from '../evaluateBoolean';
+
+describe('evaluateBoolean', () => {
+  it('returns boolean when boolean value provided', () => {
+    expect(evaluateBoolean(true, false)).toBe(true);
+    expect(evaluateBoolean(false, true)).toBe(false);
+  });
+
+  it('returns default when undefined value provided', () => {
+    expect(evaluateBoolean(undefined, false)).toBe(false);
+    expect(evaluateBoolean(undefined, true)).toBe(true);
+  });
+
+  it('parses strings into booleans', () => {
+    expect(evaluateBoolean('true', false)).toBe(true);
+    expect(evaluateBoolean('false', true)).toBe(false);
+  });
+
+  it('throws with unrecognized strings', () => {
+    expect(() => evaluateBoolean('yes', true))
+      .toThrowErrorMatchingInlineSnapshot('"serverless-better-credentials: Unrecognized boolean: "yes". Please use "true" or "false"."');
+  });
+});

--- a/src/utils/evaluateBoolean.ts
+++ b/src/utils/evaluateBoolean.ts
@@ -1,0 +1,22 @@
+/**
+ * Evaluates a string or boolean value to a boolean.
+ * Particularly useful for parsing config options.
+ */
+export default function evaluateBoolean(
+  value: string | boolean | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new Error(`serverless-better-credentials: Unrecognized boolean: "${value}". Please use "true" or "false".`);
+}


### PR DESCRIPTION
This is my first PR, so please let me know if there's anything else you'd like to see in terms of docs or tests!

## Why
- "official" fix for #8

## How
- new `enabled` config option is a flexible way to allow users to turn off plugin with `invoke local`
- this is a common way to approach the problem, e.g. see [serverless-domain-manager](https://github.dev/amplify-education/serverless-domain-manager)
