### PR TITLE
feat: add remaining default chain providers to profile chains

### DIFF
--- a/src/AwsCredentials/__tests__/AwsCredentials.test.ts
+++ b/src/AwsCredentials/__tests__/AwsCredentials.test.ts
@@ -41,11 +41,17 @@ test('constructs a chainable provider', async () => {
 test('resolves profiles as ini, sso then process', () => {
   const awsCredentials = new AwsCredentials(() => {});
   awsCredentials.addProfile('profile', 'test_profile');
-  expect(awsCredentials.chain.providers).toHaveLength(3);
+  expect(awsCredentials.chain.providers).toHaveLength(6);
   // @ts-expect-error - we know this is callable
   expect(awsCredentials.chain.providers[0]()).toBeInstanceOf(AWS.SharedIniFileCredentials);
   // @ts-expect-error - we know this is callable
   expect(awsCredentials.chain.providers[1]()).toBeInstanceOf(SsoCredentials);
   // @ts-expect-error - we know this is callable
   expect(awsCredentials.chain.providers[2]()).toBeInstanceOf(AWS.ProcessCredentials);
+  // @ts-expect-error - we know this is callable
+  expect(awsCredentials.chain.providers[3]()).toBeInstanceOf(AWS.ECSCredentials);
+  // @ts-expect-error - we know this is callable
+  expect(awsCredentials.chain.providers[4]()).toBeInstanceOf(AWS.TokenFileWebIdentityCredentials);
+  // @ts-expect-error - we know this is callable
+  expect(awsCredentials.chain.providers[5]()).toBeInstanceOf(AWS.EC2MetadataCredentials);
 });


### PR DESCRIPTION
Implements #32 

This adds the missing providers from the AWS SDK's default chain into the profile providers chain created by the plugin. They're added in the order they're defined in the default chain, but only after the existing providers created by this plugin, resulting in a chain slightly out of the default order