### PR TITLE
Support serverless v4 only peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@serverless/utils": "^6.0.2",
     "aws-sdk": "^2.567.0",
-    "serverless": "^2 || ^3"
+    "serverless": "^2 || ^3 || ^4"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
For now, I'll just make peerDependencies compatible with v4 so that I can check that it works.